### PR TITLE
Dockerfile update for consul-template installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,14 @@ MAINTAINER Shane Sveller <shane@bellycard.com>
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update -qq && \
-    apt-get -y install curl runit && \
+    apt-get -y install curl runit unzip && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CT_URL https://github.com/hashicorp/consul-template/releases/download/v0.1.0/consul-template_0.1.0_linux_amd64.tar.gz
-RUN curl -L $CT_URL | tar -C /usr/local/bin --strip-components 1 -zxf -
+ENV CT_URL https://releases.hashicorp.com/consul-template/0.15.0/consul-template_0.15.0_linux_amd64.zip
+RUN curl -o consul-template.zip $CT_URL
+RUN unzip consul-template.zip
+RUN chmod a+x consul-template
+RUN mv consul-template /usr/bin/consul-template
 
 ADD nginx.service /etc/service/nginx/run
 ADD consul-template.service /etc/service/consul-template/run


### PR DESCRIPTION
Thanks for posting this code! It seems like hashicorp is distributing consul-template as a .zip file now instead of .tar.gz, so I updated the build process (and version).  Hope it's useful! Or is there a way better way to do this kinda thing these days?
